### PR TITLE
Navigate to Home on Success

### DIFF
--- a/lib/app/presentation/logic/flashcards_logic/add_flashcard_notifier.dart
+++ b/lib/app/presentation/logic/flashcards_logic/add_flashcard_notifier.dart
@@ -10,16 +10,18 @@ enum AddFlashcardState { initial, loading, success, failed }
 
 class AddFlashcardNotifier extends StateNotifier<AddFlashcardState> {
   final AddFlashcardUsecase _usecase;
-
   AddFlashcardNotifier(this._usecase) : super(AddFlashcardState.initial);
 
   Future<String?> addFlashcard(
-      String question, String answer, String color) async {
+    String question,
+    String answer,
+    String color,
+  ) async {
     state = AddFlashcardState.loading; // begin the loading
     try {
       await _usecase.execute(question, answer, color); // handle the req
       state = AddFlashcardState.success; // req is successful
-      return null.toString();
+      return "flashcard_created";
     } on AuthException catch (e) {
       debugPrint("[CUBIT AUTH ERROR] ${e.message}");
       state = AddFlashcardState.failed;

--- a/lib/app/presentation/screens/add_flashcard_screen.dart
+++ b/lib/app/presentation/screens/add_flashcard_screen.dart
@@ -1,7 +1,10 @@
 import 'dart:math';
 
+import 'package:another_flushbar/flushbar.dart';
+import 'package:another_flushbar/flushbar_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quick_flashcards/app/core/routes/routes.dart';
 import 'package:quick_flashcards/app/data/card_model.dart';
 
 import '../../core/constants/string_constants.dart';
@@ -43,16 +46,22 @@ class _AddFlashcardScreenState extends State<AddFlashcardScreen> {
     Color randomItem = colors[randomColor];
 
     try {
-      final cardColor = widget.cardModel?.color;
       final result = await notifier.addFlashcard(
         _questionController.text,
         _answerController.text,
         randomItem.toString(),
       );
-      if (state != AddFlashcardState.success) {
-        print("can't add flashcard - ${result}");
+      if (result != "flashcard_created") {
+        debugPrint("Unable to Add Flashcard: ${state.toString()}");
+        showFlushbar(
+          context: context,
+          flushbar: Flushbar(
+            title: "Unable to Add Flashcard",
+          ),
+        );
       } else {
-        print("flashcard added - $result");
+        debugPrint("Flashcard Added!");
+        Navigator.pushNamed(context, Routes.home);
       }
     } catch (e) {
       debugPrint("${StringConstants.unknownError}: ${e.toString()}");


### PR DESCRIPTION
In this PR, I implemented the Navigator to redirect the user back to the Home Screen (where the cards are) whenever they're able to successfully create a card. In a situation whereby the users are unable to create a card (maybe because of invalid input or internet connection), a notification in the form of a snack bar will be displayed to them.